### PR TITLE
Prevent title bar borders from appearing in the applet

### DIFF
--- a/src/BudgiePixelSaverApplet.vala
+++ b/src/BudgiePixelSaverApplet.vala
@@ -205,6 +205,9 @@ public class Applet : Budgie.Applet
             .pixelsaver {
                 min-height: 0px;
                 background-color: transparent;
+                margin: -1px;
+                border-width: unset;
+                border-radius: unset;
             }
             """;
         Gdk.Screen screen=this.get_screen();


### PR DESCRIPTION
Currently, this applet doesn't work well with the **Arc** theme. Borders of a title bar appear in the applet like this:
![Screenshot from 2021-06-26 20:08:56](https://user-images.githubusercontent.com/30318985/123515974-c9ae8280-d6d4-11eb-9498-a873ceeb96c0.png)

This PR fixes that. The applet will look like this:
![Screenshot from 2021-06-26 23:09:19](https://user-images.githubusercontent.com/30318985/123516008-ec409b80-d6d4-11eb-8127-21755125e717.png)

