### PR TITLE
Allow the title to be unthemed

### DIFF
--- a/src/BudgiePixelSaverApplet.vala
+++ b/src/BudgiePixelSaverApplet.vala
@@ -39,6 +39,7 @@ public class Applet : Budgie.Applet
     private Settings? blacklist_settings;
     private Settings? wm_settings;
     private bool theme_buttons = false;
+    private bool theme_title = false;
     private int title_alignment = TITLE_ALIGNMENT_LEFT;
     private Budgie.PanelPosition panel_position = Budgie.PanelPosition.TOP;
 
@@ -201,6 +202,13 @@ public class Applet : Budgie.Applet
             this.close_button.get_style_context().remove_class("close");
         }
 
+        if (this.theme_title) {
+            this.applet_container.get_style_context().remove_class("pixelsaver_reset_title_color");
+        }
+        else {
+            this.applet_container.get_style_context().add_class("pixelsaver_reset_title_color");
+        }
+
         string container_css = """
             .pixelsaver {
                 min-height: 0px;
@@ -209,7 +217,11 @@ public class Applet : Budgie.Applet
                 border-width: unset;
                 border-radius: unset;
             }
+            .pixelsaver_reset_title_color {
+                color: unset;
+            }
             """;
+            
         Gdk.Screen screen=this.get_screen();
         Gtk.CssProvider css_provider = new Gtk.CssProvider();
         try {
@@ -285,6 +297,9 @@ public class Applet : Budgie.Applet
             }
         } else if (key == "theme-buttons") {
             this.theme_buttons = settings.get_boolean(key);
+            this.set_css_styles();
+        } else if (key == "theme-title") {
+            this.theme_title = settings.get_boolean(key);
             this.set_css_styles();
         } else if (key == "title-alignment") {
             this.title_alignment = settings.get_int(key);
@@ -414,7 +429,10 @@ public class AppletSettings : Gtk.Grid
     private Gtk.Switch? switch_unmaximized;
 
     [GtkChild]
-    private Gtk.Switch? switch_theme;
+    private Gtk.Switch? switch_theme_buttons;
+
+    [GtkChild]
+    private Gtk.Switch? switch_theme_title;
 
     [GtkChild]
     private Gtk.ComboBox? combobox_title_alignment;
@@ -427,7 +445,8 @@ public class AppletSettings : Gtk.Grid
         this.settings.bind("visibility", combobox_visibility, "active", SettingsBindFlags.DEFAULT);
         this.settings.bind("hide-for-csd", switch_csd, "active", SettingsBindFlags.DEFAULT);
         this.settings.bind("hide-for-unmaximized", switch_unmaximized, "active", SettingsBindFlags.DEFAULT);
-        this.settings.bind("theme-buttons", switch_theme, "active", SettingsBindFlags.DEFAULT);
+        this.settings.bind("theme-buttons", switch_theme_buttons, "active", SettingsBindFlags.DEFAULT);
+        this.settings.bind("theme-title", switch_theme_title, "active", SettingsBindFlags.DEFAULT);
         this.settings.bind("title-alignment", combobox_title_alignment, "active", SettingsBindFlags.DEFAULT);
     }
 }

--- a/src/net.milgar.budgie-pixel-saver.gschema.xml
+++ b/src/net.milgar.budgie-pixel-saver.gschema.xml
@@ -26,6 +26,11 @@
       <summary>Style buttons using the theme</summary>
       <description>Whether to style titlebar buttons using the current theme</description>
     </key>
+    <key type="b" name="theme-title">
+      <default>true</default>
+      <summary>Color title using the theme</summary>
+      <description>Whether to style the title using the current theme</description>
+    </key>
     <key type="i" name="title-alignment">
       <default>0</default>
       <summary>Title Alignment</summary>

--- a/src/settings.ui
+++ b/src/settings.ui
@@ -174,7 +174,7 @@ windows</property>
       <object class="GtkLabel">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
-        <property name="label" translatable="yes">Use Theme Styling</property>
+        <property name="label" translatable="yes">Theme Buttons</property>
         <property name="xalign">0</property>
       </object>
       <packing>
@@ -183,7 +183,7 @@ windows</property>
       </packing>
     </child>
     <child>
-      <object class="GtkSwitch" id="switch_theme">
+      <object class="GtkSwitch" id="switch_theme_buttons">
         <property name="visible">True</property>
         <property name="can_focus">True</property>
         <property name="halign">end</property>
@@ -199,11 +199,35 @@ windows</property>
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="halign">start</property>
-        <property name="label" translatable="yes">Title Alignment</property>
+        <property name="label" translatable="yes">Theme Title</property>
       </object>
       <packing>
         <property name="left_attach">0</property>
         <property name="top_attach">5</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkSwitch" id="switch_theme_title">
+        <property name="visible">True</property>
+        <property name="can_focus">True</property>
+        <property name="halign">end</property>
+        <property name="valign">start</property>
+      </object>
+      <packing>
+        <property name="left_attach">1</property>
+        <property name="top_attach">5</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkLabel">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="halign">start</property>
+        <property name="label" translatable="yes">Title Alignment</property>
+      </object>
+      <packing>
+        <property name="left_attach">0</property>
+        <property name="top_attach">6</property>
       </packing>
     </child>
     <child>
@@ -224,7 +248,7 @@ windows</property>
       </object>
       <packing>
         <property name="left_attach">1</property>
-        <property name="top_attach">5</property>
+        <property name="top_attach">6</property>
       </packing>
     </child>
   </template>


### PR DESCRIPTION
This PR adds an option to theme or untheme the title in addition to the buttons.
![Screenshot from 2021-06-27 14:26:32](https://user-images.githubusercontent.com/30318985/123533836-bb537b80-d753-11eb-923a-2b59b29a9498.png)

Sometimes we can read the title easily by removing the theme from it. For example,
Themed title:
![Screenshot from 2021-06-27 14:21:00](https://user-images.githubusercontent.com/30318985/123533816-81827500-d753-11eb-8318-7a9af01936f5.png)

Unthemed title:
![Screenshot from 2021-06-27 14:21:29](https://user-images.githubusercontent.com/30318985/123533819-87785600-d753-11eb-8dfa-5a2302159ffb.png)
